### PR TITLE
Basic Support for SpecFlow

### DIFF
--- a/SpellChecker.Implementation/NaturalTextTaggers/SpecFlowTextTagger.cs
+++ b/SpellChecker.Implementation/NaturalTextTaggers/SpecFlowTextTagger.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Tagging;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.Language.Spellchecker
+{
+    /// <summary>
+    /// Provides tags for SpecFlow / Gherkin Feature files.
+    /// </summary>
+    internal class SpecFlowTextTagger : ITagger<NaturalTextTag>
+    {
+        #region Private Fields
+        private ITextBuffer _buffer;
+        #endregion
+
+        #region MEF Imports / Exports
+        [Export(typeof(ITaggerProvider))]
+        [ContentType("gherkin")]
+        [FileExtension(".feature")]
+        [TagType(typeof(NaturalTextTag))]
+        internal class SpecFlowTaggerProvider : ITaggerProvider
+        {
+            public ITagger<T> CreateTagger<T>(ITextBuffer buffer) where T : ITag
+            {
+                if (buffer == null)
+                {
+                    throw new ArgumentNullException("buffer");
+                }
+
+                return new SpecFlowTextTagger(buffer) as ITagger<T>;
+            }
+        }
+        #endregion
+
+        #region Constructor
+
+        public SpecFlowTextTagger(ITextBuffer buffer)
+        {
+            _buffer = buffer;
+        }
+        #endregion
+
+        #region ITagger<INaturalTextTag> Members
+        public IEnumerable<ITagSpan<NaturalTextTag>> GetTags(NormalizedSnapshotSpanCollection spans)
+        {
+            foreach (var snapshotSpan in spans)
+            {
+                yield return new TagSpan<NaturalTextTag>(
+                        snapshotSpan,
+                        new NaturalTextTag()
+                        );
+
+            }
+        }
+
+        #pragma warning disable 67
+        public event EventHandler<SnapshotSpanEventArgs> TagsChanged;
+        #pragma warning restore 67
+        #endregion
+    }
+}

--- a/SpellChecker.Implementation/SpellChecker.csproj
+++ b/SpellChecker.Implementation/SpellChecker.csproj
@@ -84,6 +84,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="NaturalTextTaggers\CommentTextTagger.cs" />
+    <Compile Include="NaturalTextTaggers\SpecFlowTextTagger.cs" />
     <Compile Include="NaturalTextTaggers\CSharp\CSharpCommentTextTagger.cs" />
     <Compile Include="NaturalTextTaggers\CSharp\LineProgress.cs" />
     <Compile Include="NaturalTextTaggers\CSharp\State.cs" />


### PR DESCRIPTION
Hi Simon, 

I add a Basic Suport for  SpecFlow Feature Files (http://www.specflow.org/documentation/Feature-Language/). Currently it  works same way as  PlainTextTagger.

Greetings,
Sergei.
